### PR TITLE
Added support for a timeout in the command.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module docwhat.org/chronic
 
-go 1.16
+go 1.20

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -22,7 +22,7 @@ function it_shows_help_successfully { #@test
 
 function help_shows_usage { #@test
   run_chronic
-  assert_line --index 0 "Usage: chronic <command> [args]..."
+  assert_line --index 0 "Usage: chronic [-t TIMEOUT] <command> [args]..."
 }
 
 function help_shows_the_version { #@test
@@ -87,6 +87,11 @@ function it_displays_standard_error_on_failure { #@test
   run_chronic bash -c 'echo -e "In Xanadu did Kubla Khan\nA stately pleasure-dome decree" 1>&2; exit 9'
   assert_line "stderr: In Xanadu did Kubla Khan"
   assert_line "stderr: A stately pleasure-dome decree"
+}
+
+function it_displays_timeout_failure { #@test
+  run_chronic -t 1 bash -c 'sleep 5'
+  assert_line "**** Timeout, process killed! ****"
 }
 
 # EOF


### PR DESCRIPTION
Related to issue #49.

Added support for a timeout flag. Will timeout a command(and kill it) in case it take too long to execute.

Default behaviour unchanged.

Simple Test:

```
$ chronic -t 2 bash -c "echo 'out'; echo 'err' 1>&2; sleep 5"
**** Timeout, process killed! ****

**** command ****
[`bash` `-c` `echo 'out'; echo 'err' 1>&2; sleep 5`]

**** stdout ****
stdout: out

**** stderr ****
stderr: err

Exited with -1
```

Ps.: `io/ioutil` is deprecated in 1.16, if I'm not wrong.